### PR TITLE
temp fix: Modify gzil symbol on testnet

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -7,7 +7,7 @@
   "TestNet": {
     "ZIL": "zil1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9yf6pz",
     "SWTH": "zil1d6yfgycu9ythxy037hkt3phc3jf7h6rfzuft0s",
-    "gZIL": "zil1zmatu4uka68ghtt4vk5h2tdfrwkrp6pcq0y2rm",
+    "gzil": "zil1zmatu4uka68ghtt4vk5h2tdfrwkrp6pcq0y2rm",
     "XSGD": "zil10a9z324aunx2qj64984vke93gjdnzlnl5exygv"
   }
 }


### PR DESCRIPTION
Error made for the testnet gzil deployment. Symbol was all in small caps: `gzil`. 
Will be fixed for mainnet deployment. (i.e. `gZIL`)